### PR TITLE
Fix 32bit and 64bit counter selector

### DIFF
--- a/check_traffic.sh
+++ b/check_traffic.sh
@@ -1336,14 +1336,12 @@ else
 		to_debug ifIndex ${SMArray[$index]}
 
 		Flag64ContentSM=`$SNMPGET -v $Version $Community $Host IF-MIB::ifHCOutOctets.${SMArray[$index]}   2>&1`
-		if [ $? -eq 0 ]; then
-			echo $Flag64ContentSM |grep Counter64 >/dev/null 2>&1
-			Flag64=$?
-			if [ $Flag64 -eq 0  -a "$Version" = "2c" ];then
-				ifIn=$ifIn64
-				ifOut=$ifOut64
-				BitSuffix=64
-			fi
+		echo $Flag64ContentSM |grep Counter64 >/dev/null 2>&1
+		Flag64=$?
+		if [ $Flag64 -eq 0  -a "$Version" = "2c" ]; then
+			ifIn=$ifIn64
+			ifOut=$ifOut64
+			BitSuffix=64
 		else
 			ifIn=$ifIn32
 			ifOut=$ifOut32


### PR DESCRIPTION
The script fails checking 64 bit counters:

```
$ ./check_traffic.sh -V 2c -C public  -H 192.168.1.89 -I 1 -w 200,200 -c 300,300 -K -B
IF-MIB::.1: Unknown Object Identifier
IF-MIB::.1: Unknown Object Identifier
No Data been get here. Please confirm your ARGS and re-check it with Verbose mode, then to check the log.(If you snmp not support 64 bit counter, do not use -6 option)
```

That's because snmpget exit code is not reliable:

```
$ /usr/bin/snmpget -t 15 -Oa -v 2c -c public 192.168.1.89 IF-MIB::ifHCOutOctets.1
IF-MIB::ifHCOutOctets.1 = No Such Object available on this agent at this OID
$ echo $?
0
```

```
$ /usr/bin/snmpget -t 15 -Oa -v 2c -c public 192.168.1.89 IF-MIB::ifOutOctets.1
IF-MIB::ifOutOctets.1 = Counter32: 4050020
$ echo $?
0
```

The patch checks the snmpget output instead of the error code in order to choose a 32counter or a 64counter.
